### PR TITLE
Supervisor default restart

### DIFF
--- a/masabot/__init__.py
+++ b/masabot/__init__.py
@@ -4,9 +4,17 @@ import sys
 from . import bot
 
 
+_log = logging.getLogger("masabot")  # use exact module name because name might be __main__
+_log.setLevel(logging.DEBUG)
+
+
 def run():
 	_setup_logger()
-	bot.start()
+	# noinspection PyBroadException
+	try:
+		bot.start()
+	except Exception:
+		_log.exception("Exception in main thread")
 
 
 class _ExactLevelFilter(object):

--- a/masabot/bot.py
+++ b/masabot/bot.py
@@ -263,9 +263,12 @@ class MasaBot(object):
 		"""
 		Begin execution of bot. Blocks until complete.
 		"""
-		self._master_timer_task = self._client.loop.create_task(self._run_timer())
 		_log.info("Connecting...")
-		self._client.run(self._api_key)
+		try:
+			self._master_timer_task = self._client.loop.create_task(self._run_timer())
+			self._client.run(self._api_key)
+		finally:
+			self._client.close()
 
 	def is_nsfw_channel(self, ch_context):
 		"""
@@ -568,8 +571,10 @@ class MasaBot(object):
 					msg = "Oh yeah, the `" + m.name + "` module! `" + m.description + "`\n\n" + m.help_text
 		await self.reply(context, msg)
 
-	async def quit(self, context):
+	async def quit(self, context, restart_command="quit"):
 		self.require_op(context, "quit", None)
+		with open('.supervisor/restart-command', 'w') as fp:
+			fp.write(restart_command)
 		await self.reply(context, "Right away, <@!" + context.author.id + ">! See you later!")
 		_log.info("Shutting down...")
 		self._master_timer_task.cancel()
@@ -880,8 +885,6 @@ class MasaBot(object):
 
 	async def _redeploy(self, context, reason=None):
 		self.require_op(context, "redeploy", None)
-		with open('.supervisor/restart-command', 'w') as fp:
-			fp.write("redeploy")
 		if reason is not None:
 			with open('.supervisor/reason', 'w') as fp:
 				fp.write(reason)
@@ -889,7 +892,7 @@ class MasaBot(object):
 		msg = "Oh! It looks like " + context.author_name() + " has triggered a redeploy. I'll be going down now, but"
 		msg += " don't worry! I'll be right back!"
 		await self.announce(msg)
-		await self.quit(context)
+		await self.quit(context, "redeploy")
 
 	async def _check_supervisor_files(self):
 		if not os.path.exists('.supervisor/status'):
@@ -906,7 +909,7 @@ class MasaBot(object):
 		os.remove('.supervisor/status')
 		if status['action'] == 'redeploy':
 			if status['success']:
-				msg = "My redeploy completed! Yay, everything went well!\n\n"
+				msg = "My deploy completed! Yay, everything went well!\n\n"
 
 				if len(status['packages']) < 1:
 					msg += "There were no changes to my dependencies."
@@ -929,7 +932,7 @@ class MasaBot(object):
 				if reason is not None:
 					msg += "\n\n--------\n\nOh! Oh! I gotta tell you! The whole reason I went down is because " + reason
 			else:
-				msg = "Oh no, it looks like something went wrong during my redeploy :c\n\n"
+				msg = "Oh no, it looks like something went wrong during my deploy :c\n\n"
 				if not status['check_package_success']:
 					msg += "Something went wrong when I was looking for new packages to install!\n\n"
 				msg += "```\n" + status['message'] + "\n"
@@ -1278,7 +1281,13 @@ def start():
 	if not os.path.exists('resources'):
 		os.mkdir('resources')
 	bot = MasaBot("config.json")
-	bot.run()
+	try:
+		bot.run()
+	except KeyboardInterrupt:
+		# this is a normal shutdown, so notify any supervisor by writing to the restart-command file
+		with open('.supervisor/restart-command', 'w') as fp:
+			fp.write("quit")
+		raise
 
 
 def _copy_handler_dict(dict_to_copy):

--- a/masabot/bot.py
+++ b/masabot/bot.py
@@ -907,9 +907,11 @@ class MasaBot(object):
 		else:
 			reason = None
 		os.remove('.supervisor/status')
-		if status['action'] == 'redeploy':
-			if status['success']:
-				msg = "My deploy completed! Yay, everything went well!\n\n"
+		action = status['action']
+		msg = None
+		if action == 'redeploy' or action == 'deploy':
+			if action == 'redeploy' and status['success']:
+				msg = "My redeploy completed! Yay, everything went well!\n\n"
 
 				if len(status['packages']) < 1:
 					msg += "There were no changes to my dependencies."
@@ -931,8 +933,8 @@ class MasaBot(object):
 
 				if reason is not None:
 					msg += "\n\n--------\n\nOh! Oh! I gotta tell you! The whole reason I went down is because " + reason
-			else:
-				msg = "Oh no, it looks like something went wrong during my deploy :c\n\n"
+			elif not status['success']:
+				msg = "Oh no, it looks like something went wrong during my " + action + " :c\n\n"
 				if not status['check_package_success']:
 					msg += "Something went wrong when I was looking for new packages to install!\n\n"
 				msg += "```\n" + status['message'] + "\n"
@@ -946,7 +948,8 @@ class MasaBot(object):
 						ch_msg = " -\n" + change['message'] + "\n"
 					msg += "* " + pkg + ": " + change['action'] + " " + ch_status + ch_msg
 				msg += "```"
-			await self.announce(msg)
+			if msg is not None:
+				await self.announce(msg)
 
 	def _load_modules(self, state_dict, module_configs):
 		names = []

--- a/run-masabot.sh
+++ b/run-masabot.sh
@@ -53,8 +53,13 @@ do
         then
             git pull
             python supervisor/supervisor.py redeploy
+        elif [ "$cmd" = "quit" ]
+        then
+            running=
+            echo "Clean shutdown"
         fi
     else
-        running=
+        echo "Unclean shutdown; restarting bot in 30 seconds..."
+        sleep 30
     fi
 done

--- a/run-masabot.sh
+++ b/run-masabot.sh
@@ -40,7 +40,7 @@ else
     mkdir ".supervisor"
 fi
 
-python supervisor/supervisor.py redeploy
+python supervisor/supervisor.py initial-deploy
 
 while [ -n "$running" ]
 do

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
 		sys.exit(2)
 
 	if sys.argv[1] == 'redeploy':
-		print("Running redeploy...")
+		print("Running deploy...")
 		output = redeploy()
 	else:
 		print("Unknown subcommand '" + sys.argv[1] + "'", file=sys.stderr)

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -79,7 +79,7 @@ def run_venv_shell(exe):
 	return lines
 
 
-def redeploy():
+def deploy(is_redeploy=False):
 	installed = []
 	if os.path.exists(os.path.join('.supervisor', 'installed-packages')):
 		with open(os.path.join('.supervisor', 'installed-packages'), 'r') as fp:
@@ -87,7 +87,7 @@ def redeploy():
 				installed.append(line.strip())
 
 	output_dict = {
-		'action': "redeploy"
+		'action': "redeploy" if is_redeploy else "deploy"
 	}
 
 	try:
@@ -166,8 +166,11 @@ if __name__ == "__main__":
 		sys.exit(2)
 
 	if sys.argv[1] == 'redeploy':
+		print("Running redeploy...")
+		output = deploy(is_redeploy=True)
+	elif sys.argv[1] == 'initial-deploy':
 		print("Running deploy...")
-		output = redeploy()
+		output = deploy()
 	else:
 		print("Unknown subcommand '" + sys.argv[1] + "'", file=sys.stderr)
 		sys.exit(3)


### PR DESCRIPTION
The supervisor now defaults to restarting the bot on an unclean shutdown. If `!quit` is not given or the supervisor is not stopped externally, it will always restart the bot.