### PR TITLE
Fix incorrect quotes

### DIFF
--- a/masabot/bot.py
+++ b/masabot/bot.py
@@ -1560,7 +1560,7 @@ class MasaBot(object):
 		""":type : str"""
 
 		# special case; do NOT apply replacements if the replchars command is being invoked:
-		pre_analyze = shlex.split(content)
+		pre_analyze = content.split()
 		if pre_analyze[0] == 'replchars':
 			tokens = pre_analyze
 		else:


### PR DESCRIPTION
fixes #32, shlex was complaining because we didn't do quote replacements before trying to split (because of the replchars edgecase). Since all that first split is looking for is to identify the replchars token, the built-in python string.split works fine