### PR TITLE
Make commands non-case-sensitive

### DIFF
--- a/masabot/bot.py
+++ b/masabot/bot.py
@@ -1570,6 +1570,8 @@ class MasaBot(object):
 
 			tokens = shlex.split(content)
 
+		tokens[0] = tokens[0].lower()
+
 		return tokens
 
 	def _load_builtin_state(self, state_dict):


### PR DESCRIPTION
Fixes #29, commands can be in any case now (but must now stick to lowercase on the dev side. That style is already adhered to so it should be fine)